### PR TITLE
added dbt-diagrams docs serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ models:
 Using the `meta` section of a model, you can define ERD connections to other models. Based on these connections and other table attributes the ERD can be generated. The `target` attribute is another dbt model name. Accepted relation cardinalities are `one`, `zero_or_one`, `zero_or_more` or `one_or_more`. Use the `label` attribute to specify a human readable interpretation to a relation. The `diagram` is optional and allows you to add a name to your ERD. This is useful in case you want to define multiple ERDs and reference them in dbt docs directly.
 
 Notice the `mermaid[erd="cusomer_erd"]` expressions in the `customers` and `orders` model descriptions. When running `dbt-diagrams docs generate`, this will be replaced by the ERD Mermaid definition so that your ERD can be rendered in any dbt docs page.
+After generating the docs, you can run `dbt-diagrams docs serve` to view the docs with the rendered Mermaid diagrams. This command preserves the embedded diagrams (unlike `dbt docs serve`, which would regenerate the HTML and remove them).
 
 ```mermaid
 erDiagram

--- a/dbt_diagrams/cli.py
+++ b/dbt_diagrams/cli.py
@@ -41,29 +41,30 @@ def get_target_dir():
     """Get the dbt target directory using the same precedence as dbt"""
     # Check CLI args (would need to be passed through if needed)
     cli_target_path = None
-    
+
     # Check environment variable
     env_target_path = os.environ.get("DBT_TARGET_PATH")
-    
+
     # Check dbt_project.yml
     dbt_project_target_path = None
     if os.path.exists("./dbt_project.yml"):
         with open("./dbt_project.yml", "r") as dbt_project_file:
             dbt_project_target_path = yaml.safe_load(dbt_project_file.read()).get("target-path")
-    
+
     # Return first available option following dbt's precedence
     target_dir = Path(
         next(
-            td for td in [
+            td
+            for td in [
                 cli_target_path,
-                env_target_path, 
+                env_target_path,
                 dbt_project_target_path,
                 "./target",
             ]
             if td is not None
         )
     )
-    
+
     return target_dir
 
 
@@ -155,6 +156,7 @@ async def render_erds(ctx, dbt_target_dir, manifest, catalog, format, output_dir
         write_as_mmd(diagrams, output_dir)
 
     click.secho(f"Finished. Output written to {output_dir.cwd()}.", fg="green")
+
 
 # Disable REST API for now because of multi-ERD support that needs to be built-in.
 
@@ -300,7 +302,7 @@ def generate(ctx, include_columns, docs_args):
 )
 def serve(ctx, port, browser, target_path):
     """
-    Serve dbt docs with ERDs included. Preserves any customized index.html files 
+    Serve dbt docs with ERDs included. Preserves any customized index.html files
     (such as those with embedded Mermaid diagrams) instead of overwriting them.
     """
     try:
@@ -309,20 +311,18 @@ def serve(ctx, port, browser, target_path):
             target_dir = Path(target_path)
         else:
             target_dir = get_target_dir()
-        
+
         # Ensure target directory exists
         if not target_dir.exists():
             exit_with_error(f"Target directory does not exist: {target_dir}")
-        
+
         # Change to target directory
         os.chdir(target_dir)
-        
+
         # Check if docs files exist (they should after running generate)
         if not os.path.exists("index.html"):
-            exit_with_error(
-                "index.html not found. Please run 'dbt-diagrams docs generate' first."
-            )
-        
+            exit_with_error("index.html not found. Please run 'dbt-diagrams docs generate' first.")
+
         required_files = ["manifest.json"]
         missing_files = [f for f in required_files if not os.path.exists(f)]
         if missing_files:
@@ -330,24 +330,24 @@ def serve(ctx, port, browser, target_path):
                 f"Missing required files: {', '.join(missing_files)}. "
                 f"Please run 'dbt-diagrams docs generate' first."
             )
-        
+
         click.echo("Using existing docs (with ERDs and customizations)...")
-        
+
         # Open browser if requested
         if browser:
             webbrowser.open_new_tab(f"http://localhost:{port}")
-        
+
         # Start the server
         with socketserver.TCPServer(("", port), SimpleHTTPRequestHandler) as httpd:
             click.secho(f"Serving docs at http://localhost:{port}", fg="green")
             click.echo(f"Target directory: {target_dir.absolute()}")
             click.echo("\nPress Ctrl+C to exit.")
-            
+
             try:
                 httpd.serve_forever()
             except KeyboardInterrupt:
                 click.echo("\nShutting down server...")
-                
+
     except Exception as e:
         if ctx.obj["debug"]:
             traceback.print_exc()

--- a/dbt_diagrams/cli.py
+++ b/dbt_diagrams/cli.py
@@ -316,17 +316,9 @@ def serve(ctx, port, browser, target_path):
         if not target_dir.exists():
             exit_with_error(f"Target directory does not exist: {target_dir}")
 
-        # Check if docs files exist (they should after running generate)
+        # Check if docs have been generated
         if not (target_dir / "index.html").exists():
-            exit_with_error("index.html not found. Please run 'dbt-diagrams docs generate' first.")
-
-        required_files = ["manifest.json"]
-        missing_files = [f for f in required_files if not (target_dir / f).exists()]
-        if missing_files:
-            exit_with_error(
-                f"Missing required files: {', '.join(missing_files)}. "
-                f"Please run 'dbt-diagrams docs generate' first."
-            )
+            exit_with_error("Documentation not found. Please run 'dbt-diagrams docs generate' first.")
 
         click.echo("Using existing docs (with ERDs and customizations)...")
 

--- a/dbt_diagrams/cli.py
+++ b/dbt_diagrams/cli.py
@@ -318,7 +318,9 @@ def serve(ctx, port, browser, target_path):
 
         # Check if docs have been generated
         if not (target_dir / "index.html").exists():
-            exit_with_error("Documentation not found. Please run 'dbt-diagrams docs generate' first.")
+            exit_with_error(
+                "Documentation not found. Please run 'dbt-diagrams docs generate' first."
+            )
 
         click.echo("Using existing docs (with ERDs and customizations)...")
 
@@ -327,6 +329,7 @@ def serve(ctx, port, browser, target_path):
             webbrowser.open_new_tab(f"http://localhost:{port}")
 
         import functools
+
         handler = functools.partial(SimpleHTTPRequestHandler, directory=str(target_dir))
         with socketserver.TCPServer(("", port), handler) as httpd:
             click.secho(f"Serving docs at http://localhost:{port}", fg="green")

--- a/dbt_diagrams/cli.py
+++ b/dbt_diagrams/cli.py
@@ -47,7 +47,7 @@ def get_target_dir():
 
     # Check dbt_project.yml
     dbt_project_target_path = None
-    if os.path.exists("./dbt_project.yml"):
+    if Path("./dbt_project.yml").exists():
         with open("./dbt_project.yml", "r") as dbt_project_file:
             dbt_project_target_path = yaml.safe_load(dbt_project_file.read()).get("target-path")
 
@@ -320,11 +320,11 @@ def serve(ctx, port, browser, target_path):
         os.chdir(target_dir)
 
         # Check if docs files exist (they should after running generate)
-        if not os.path.exists("index.html"):
+        if not Path("index.html").exists():
             exit_with_error("index.html not found. Please run 'dbt-diagrams docs generate' first.")
 
         required_files = ["manifest.json"]
-        missing_files = [f for f in required_files if not os.path.exists(f)]
+        missing_files = [f for f in required_files if not Path(f).exists()]
         if missing_files:
             exit_with_error(
                 f"Missing required files: {', '.join(missing_files)}. "

--- a/dbt_diagrams/cli.py
+++ b/dbt_diagrams/cli.py
@@ -316,10 +316,16 @@ def serve(ctx, port, browser, target_path):
         if not target_dir.exists():
             exit_with_error(f"Target directory does not exist: {target_dir}")
 
-        # Check if docs have been generated
+        # Check if docs files exist (they should after running generate)
         if not (target_dir / "index.html").exists():
+            exit_with_error("index.html not found. Please run 'dbt-diagrams docs generate' first.")
+
+        required_files = ["manifest.json", "catalog.json"]
+        missing_files = [f for f in required_files if not (target_dir / f).exists()]
+        if missing_files:
             exit_with_error(
-                "Documentation not found. Please run 'dbt-diagrams docs generate' first."
+                f"Missing required files: {', '.join(missing_files)}. "
+                f"Please run 'dbt-diagrams docs generate' first."
             )
 
         click.echo("Using existing docs (with ERDs and customizations)...")


### PR DESCRIPTION
## Summary
Added `dbt-diagrams docs serve` CLI command to serve dbt documentation with embedded ERD diagrams.

## Changes
- **New Command**: Added `dbt-diagrams docs serve` that serves existing files without regenerating them
- **Documentation**: Updated README.md to explain the new serve command and its usage

## Reason
The original `dbt docs serve` command regenerates the `index.html` file each time it runs, which overwrites any customizations made by `dbt-diagrams docs generate`.

This new command preserves the files by serving the existing files as-is.

## How It Works
`dbt-diagrams docs serve`:
1. Locates the target directory
2. Validates that required files exist (generated by `dbt-diagrams docs generate`)
3. Serves the existing files using a simple HTTP server